### PR TITLE
AIOHTTP Version Bump

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.8.5
+aiohttp==3.8.6
 aiosignal==1.3.1
 async-timeout==4.0.2
 attrs==22.2.0


### PR DESCRIPTION
Updated AIOHTTP to 3.8.6 for dependency reasons. Unable to test properly because I don't have the token, but it _should_ be fine