### PR TITLE
aiohttp version bump for CVE-2024-52304

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.10.2
+aiohttp==3.10.11
 aiosignal==1.3.1
 async-timeout==4.0.2
 attrs==22.2.0
@@ -7,4 +7,4 @@ discord.py==2.2.2
 frozenlist==1.3.3
 idna==3.7
 multidict==6.0.4
-yarl==1.8.2
+yarl==1.12.0


### PR DESCRIPTION
bumped version to 3.10.11, also yarl to 1.12.0 as is a dependency